### PR TITLE
ESP32-S3 Bus Expander Zigbee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,30 @@ jobs:
 
       - name: Run PlatformIO native tests
         run: pio test -e native-tests
+
+  firmware-builds:
+    name: Build firmware
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        env: [s3-devkit, c6-devkit]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade platformio
+          pio --version
+
+      - name: Run PlatformIO build
+        run: pio run -e ${{ matrix.env }}

--- a/lib/OneWire/.piopm
+++ b/lib/OneWire/.piopm
@@ -1,0 +1,1 @@
+{"type": "library", "name": "OneWire", "version": "2.3.8", "spec": {"owner": "paulstoffregen", "id": 1, "name": "OneWire", "requirements": null, "uri": null}}

--- a/lib/OneWire/OneWire.cpp
+++ b/lib/OneWire/OneWire.cpp
@@ -1,0 +1,603 @@
+/*
+Copyright (c) 2007, Jim Studt  (original old version - many contributors since)
+
+The latest version of this library may be found at:
+  http://www.pjrc.com/teensy/td_libs_OneWire.html
+
+OneWire has been maintained by Paul Stoffregen (paul@pjrc.com) since
+January 2010.
+
+DO NOT EMAIL for technical support, especially not for ESP chips!
+All project support questions must be posted on public forums
+relevant to the board or chips used.  If using Arduino, post on
+Arduino's forum.  If using ESP, post on the ESP community forums.
+There is ABSOLUTELY NO TECH SUPPORT BY PRIVATE EMAIL!
+
+Github's issue tracker for OneWire should be used only to report
+specific bugs.  DO NOT request project support via Github.  All
+project and tech support questions must be posted on forums, not
+github issues.  If you experience a problem and you are not
+absolutely sure it's an issue with the library, ask on a forum
+first.  Only use github to report issues after experts have
+confirmed the issue is with OneWire rather than your project.
+
+Back in 2010, OneWire was in need of many bug fixes, but had
+been abandoned the original author (Jim Studt).  None of the known
+contributors were interested in maintaining OneWire.  Paul typically
+works on OneWire every 6 to 12 months.  Patches usually wait that
+long.  If anyone is interested in more actively maintaining OneWire,
+please contact Paul (this is pretty much the only reason to use
+private email about OneWire).
+
+OneWire is now very mature code.  No changes other than adding
+definitions for newer hardware support are anticipated.
+
+  ESP32 mods authored by stickbreaker:
+  @stickbreaker 30APR2018 add IRAM_ATTR to read_bit() write_bit() to solve ICache miss timing failure. 
+      thanks @everslick re:  https://github.com/espressif/arduino-esp32/issues/1335
+  Altered by garyd9 for clean merge with Paul Stoffregen's source
+
+Version 2.3:
+  Unknown chip fallback mode, Roger Clark
+  Teensy-LC compatibility, Paul Stoffregen
+  Search bug fix, Love Nystrom
+
+Version 2.2:
+  Teensy 3.0 compatibility, Paul Stoffregen, paul@pjrc.com
+  Arduino Due compatibility, http://arduino.cc/forum/index.php?topic=141030
+  Fix DS18B20 example negative temperature
+  Fix DS18B20 example's low res modes, Ken Butcher
+  Improve reset timing, Mark Tillotson
+  Add const qualifiers, Bertrik Sikken
+  Add initial value input to crc16, Bertrik Sikken
+  Add target_search() function, Scott Roberts
+
+Version 2.1:
+  Arduino 1.0 compatibility, Paul Stoffregen
+  Improve temperature example, Paul Stoffregen
+  DS250x_PROM example, Guillermo Lovato
+  PIC32 (chipKit) compatibility, Jason Dangel, dangel.jason AT gmail.com
+  Improvements from Glenn Trewitt:
+  - crc16() now works
+  - check_crc16() does all of calculation/checking work.
+  - Added read_bytes() and write_bytes(), to reduce tedious loops.
+  - Added ds2408 example.
+  Delete very old, out-of-date readme file (info is here)
+
+Version 2.0: Modifications by Paul Stoffregen, January 2010:
+http://www.pjrc.com/teensy/td_libs_OneWire.html
+  Search fix from Robin James
+    http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1238032295/27#27
+  Use direct optimized I/O in all cases
+  Disable interrupts during timing critical sections
+    (this solves many random communication errors)
+  Disable interrupts during read-modify-write I/O
+  Reduce RAM consumption by eliminating unnecessary
+    variables and trimming many to 8 bits
+  Optimize both crc8 - table version moved to flash
+
+Modified to work with larger numbers of devices - avoids loop.
+Tested in Arduino 11 alpha with 12 sensors.
+26 Sept 2008 -- Robin James
+http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1238032295/27#27
+
+Updated to work with arduino-0008 and to include skip() as of
+2007/07/06. --RJL20
+
+Modified to calculate the 8-bit CRC directly, avoiding the need for
+the 256-byte lookup table to be loaded in RAM.  Tested in arduino-0010
+-- Tom Pollard, Jan 23, 2008
+
+Jim Studt's original library was modified by Josh Larios.
+
+Tom Pollard, pollard@alum.mit.edu, contributed around May 20, 2008
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Much of the code was inspired by Derek Yerger's code, though I don't
+think much of that remains.  In any event that was..
+    (copyleft) 2006 by Derek Yerger - Free to distribute freely.
+
+The CRC code was excerpted and inspired by the Dallas Semiconductor
+sample code bearing this copyright.
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//--------------------------------------------------------------------------
+*/
+
+#include <Arduino.h>
+#include "OneWire.h"
+#include "util/OneWire_direct_gpio.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+// due to the dual core esp32, a critical section works better than disabling interrupts
+#  define noInterrupts() {portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;portENTER_CRITICAL(&mux)
+#  define interrupts() portEXIT_CRITICAL(&mux);}
+// for info on this, search "IRAM_ATTR" at https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/general-notes.html 
+#  define CRIT_TIMING IRAM_ATTR
+#else
+#  define CRIT_TIMING 
+#endif
+
+
+void OneWire::begin(uint8_t pin)
+{
+	pinMode(pin, INPUT);
+	bitmask = PIN_TO_BITMASK(pin);
+	baseReg = PIN_TO_BASEREG(pin);
+#if ONEWIRE_SEARCH
+	reset_search();
+#endif
+}
+
+
+// Perform the onewire reset function.  We will wait up to 250uS for
+// the bus to come high, if it doesn't then it is broken or shorted
+// and we return a 0;
+//
+// Returns 1 if a device asserted a presence pulse, 0 otherwise.
+//
+uint8_t CRIT_TIMING OneWire::reset(void)
+{
+	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
+	__attribute__((unused)) volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
+	uint8_t r;
+	uint8_t retries = 125;
+
+	noInterrupts();
+	DIRECT_MODE_INPUT(reg, mask);
+	interrupts();
+	// wait until the wire is high... just in case
+	do {
+		if (--retries == 0) return 0;
+		delayMicroseconds(2);
+	} while ( !DIRECT_READ(reg, mask));
+
+	noInterrupts();
+	DIRECT_WRITE_LOW(reg, mask);
+	DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
+	interrupts();
+	delayMicroseconds(480);
+	noInterrupts();
+	DIRECT_MODE_INPUT(reg, mask);	// allow it to float
+	delayMicroseconds(70);
+	r = !DIRECT_READ(reg, mask);
+	interrupts();
+	delayMicroseconds(410);
+	return r;
+}
+
+//
+// Write a bit. Port and bit is used to cut lookup time and provide
+// more certain timing.
+//
+void CRIT_TIMING OneWire::write_bit(uint8_t v)
+{
+	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
+	__attribute__((unused)) volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
+
+	if (v & 1) {
+		noInterrupts();
+		DIRECT_WRITE_LOW(reg, mask);
+		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
+		delayMicroseconds(10);
+		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
+		interrupts();
+		delayMicroseconds(55);
+	} else {
+		noInterrupts();
+		DIRECT_WRITE_LOW(reg, mask);
+		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
+		delayMicroseconds(65);
+		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
+		interrupts();
+		delayMicroseconds(5);
+	}
+}
+
+//
+// Read a bit. Port and bit is used to cut lookup time and provide
+// more certain timing.
+//
+uint8_t CRIT_TIMING OneWire::read_bit(void)
+{
+	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
+	__attribute__((unused)) volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
+	uint8_t r;
+
+	noInterrupts();
+	DIRECT_MODE_OUTPUT(reg, mask);
+	DIRECT_WRITE_LOW(reg, mask);
+	delayMicroseconds(3);
+	DIRECT_MODE_INPUT(reg, mask);	// let pin float, pull up will raise
+	delayMicroseconds(10);
+	r = DIRECT_READ(reg, mask);
+	interrupts();
+	delayMicroseconds(53);
+	return r;
+}
+
+//
+// Write a byte. The writing code uses the active drivers to raise the
+// pin high, if you need power after the write (e.g. DS18S20 in
+// parasite power mode) then set 'power' to 1, otherwise the pin will
+// go tri-state at the end of the write to avoid heating in a short or
+// other mishap.
+//
+void OneWire::write(uint8_t v, uint8_t power /* = 0 */) {
+    uint8_t bitMask;
+
+    for (bitMask = 0x01; bitMask; bitMask <<= 1) {
+	OneWire::write_bit( (bitMask & v)?1:0);
+    }
+    if ( !power) {
+	noInterrupts();
+	DIRECT_MODE_INPUT(baseReg, bitmask);
+	DIRECT_WRITE_LOW(baseReg, bitmask);
+	interrupts();
+    }
+}
+
+void OneWire::write_bytes(const uint8_t *buf, uint16_t count, bool power /* = 0 */) {
+  for (uint16_t i = 0 ; i < count ; i++)
+    write(buf[i]);
+  if (!power) {
+    noInterrupts();
+    DIRECT_MODE_INPUT(baseReg, bitmask);
+    DIRECT_WRITE_LOW(baseReg, bitmask);
+    interrupts();
+  }
+}
+
+//
+// Read a byte
+//
+uint8_t OneWire::read() {
+    uint8_t bitMask;
+    uint8_t r = 0;
+
+    for (bitMask = 0x01; bitMask; bitMask <<= 1) {
+	if ( OneWire::read_bit()) r |= bitMask;
+    }
+    return r;
+}
+
+void OneWire::read_bytes(uint8_t *buf, uint16_t count) {
+  for (uint16_t i = 0 ; i < count ; i++)
+    buf[i] = read();
+}
+
+//
+// Do a ROM select
+//
+void OneWire::select(const uint8_t rom[8])
+{
+    uint8_t i;
+
+    write(0x55);           // Choose ROM
+
+    for (i = 0; i < 8; i++) write(rom[i]);
+}
+
+//
+// Do a ROM skip
+//
+void OneWire::skip()
+{
+    write(0xCC);           // Skip ROM
+}
+
+void OneWire::depower()
+{
+	noInterrupts();
+	DIRECT_MODE_INPUT(baseReg, bitmask);
+	interrupts();
+}
+
+#if ONEWIRE_SEARCH
+
+//
+// You need to use this function to start a search again from the beginning.
+// You do not need to do it for the first search, though you could.
+//
+void OneWire::reset_search()
+{
+  // reset the search state
+  LastDiscrepancy = 0;
+  LastDeviceFlag = false;
+  LastFamilyDiscrepancy = 0;
+  for(int i = 7; ; i--) {
+    ROM_NO[i] = 0;
+    if ( i == 0) break;
+  }
+}
+
+// Setup the search to find the device type 'family_code' on the next call
+// to search(*newAddr) if it is present.
+//
+void OneWire::target_search(uint8_t family_code)
+{
+   // set the search state to find SearchFamily type devices
+   ROM_NO[0] = family_code;
+   for (uint8_t i = 1; i < 8; i++)
+      ROM_NO[i] = 0;
+   LastDiscrepancy = 64;
+   LastFamilyDiscrepancy = 0;
+   LastDeviceFlag = false;
+}
+
+//
+// Perform a search. If this function returns a '1' then it has
+// enumerated the next device and you may retrieve the ROM from the
+// OneWire::address variable. If there are no devices, no further
+// devices, or something horrible happens in the middle of the
+// enumeration then a 0 is returned.  If a new device is found then
+// its address is copied to newAddr.  Use OneWire::reset_search() to
+// start over.
+//
+// --- Replaced by the one from the Dallas Semiconductor web site ---
+//--------------------------------------------------------------------------
+// Perform the 1-Wire Search Algorithm on the 1-Wire bus using the existing
+// search state.
+// Return TRUE  : device found, ROM number in ROM_NO buffer
+//        FALSE : device not found, end of search
+//
+bool OneWire::search(uint8_t *newAddr, bool search_mode /* = true */)
+{
+   uint8_t id_bit_number;
+   uint8_t last_zero, rom_byte_number;
+   bool    search_result;
+   uint8_t id_bit, cmp_id_bit;
+
+   unsigned char rom_byte_mask, search_direction;
+
+   // initialize for search
+   id_bit_number = 1;
+   last_zero = 0;
+   rom_byte_number = 0;
+   rom_byte_mask = 1;
+   search_result = false;
+
+   // if the last call was not the last one
+   if (!LastDeviceFlag) {
+      // 1-Wire reset
+      if (!reset()) {
+         // reset the search
+         LastDiscrepancy = 0;
+         LastDeviceFlag = false;
+         LastFamilyDiscrepancy = 0;
+         return false;
+      }
+
+      // issue the search command
+      if (search_mode == true) {
+        write(0xF0);   // NORMAL SEARCH
+      } else {
+        write(0xEC);   // CONDITIONAL SEARCH
+      }
+
+      // loop to do the search
+      do
+      {
+         // read a bit and its complement
+         id_bit = read_bit();
+         cmp_id_bit = read_bit();
+
+         // check for no devices on 1-wire
+         if ((id_bit == 1) && (cmp_id_bit == 1)) {
+            break;
+         } else {
+            // all devices coupled have 0 or 1
+            if (id_bit != cmp_id_bit) {
+               search_direction = id_bit;  // bit write value for search
+            } else {
+               // if this discrepancy if before the Last Discrepancy
+               // on a previous next then pick the same as last time
+               if (id_bit_number < LastDiscrepancy) {
+                  search_direction = ((ROM_NO[rom_byte_number] & rom_byte_mask) > 0);
+               } else {
+                  // if equal to last pick 1, if not then pick 0
+                  search_direction = (id_bit_number == LastDiscrepancy);
+               }
+               // if 0 was picked then record its position in LastZero
+               if (search_direction == 0) {
+                  last_zero = id_bit_number;
+
+                  // check for Last discrepancy in family
+                  if (last_zero < 9)
+                     LastFamilyDiscrepancy = last_zero;
+               }
+            }
+
+            // set or clear the bit in the ROM byte rom_byte_number
+            // with mask rom_byte_mask
+            if (search_direction == 1)
+              ROM_NO[rom_byte_number] |= rom_byte_mask;
+            else
+              ROM_NO[rom_byte_number] &= ~rom_byte_mask;
+
+            // serial number search direction write bit
+            write_bit(search_direction);
+
+            // increment the byte counter id_bit_number
+            // and shift the mask rom_byte_mask
+            id_bit_number++;
+            rom_byte_mask <<= 1;
+
+            // if the mask is 0 then go to new SerialNum byte rom_byte_number and reset mask
+            if (rom_byte_mask == 0) {
+                rom_byte_number++;
+                rom_byte_mask = 1;
+            }
+         }
+      }
+      while(rom_byte_number < 8);  // loop until through all ROM bytes 0-7
+
+      // if the search was successful then
+      if (!(id_bit_number < 65)) {
+         // search successful so set LastDiscrepancy,LastDeviceFlag,search_result
+         LastDiscrepancy = last_zero;
+
+         // check for last device
+         if (LastDiscrepancy == 0) {
+            LastDeviceFlag = true;
+         }
+         search_result = true;
+      }
+   }
+
+   // if no device found then reset counters so next 'search' will be like a first
+   if (!search_result || !ROM_NO[0]) {
+      LastDiscrepancy = 0;
+      LastDeviceFlag = false;
+      LastFamilyDiscrepancy = 0;
+      search_result = false;
+   } else {
+      for (int i = 0; i < 8; i++) newAddr[i] = ROM_NO[i];
+   }
+   return search_result;
+  }
+
+#endif
+
+#if ONEWIRE_CRC
+// The 1-Wire CRC scheme is described in Maxim Application Note 27:
+// "Understanding and Using Cyclic Redundancy Checks with Maxim iButton Products"
+//
+
+#if ONEWIRE_CRC8_TABLE
+// Dow-CRC using polynomial X^8 + X^5 + X^4 + X^0
+// Tiny 2x16 entry CRC table created by Arjen Lentz
+// See http://lentz.com.au/blog/calculating-crc-with-a-tiny-32-entry-lookup-table
+static const uint8_t PROGMEM dscrc2x16_table[] = {
+	0x00, 0x5E, 0xBC, 0xE2, 0x61, 0x3F, 0xDD, 0x83,
+	0xC2, 0x9C, 0x7E, 0x20, 0xA3, 0xFD, 0x1F, 0x41,
+	0x00, 0x9D, 0x23, 0xBE, 0x46, 0xDB, 0x65, 0xF8,
+	0x8C, 0x11, 0xAF, 0x32, 0xCA, 0x57, 0xE9, 0x74
+};
+
+// Compute a Dallas Semiconductor 8 bit CRC. These show up in the ROM
+// and the registers.  (Use tiny 2x16 entry CRC table)
+uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
+{
+	uint8_t crc = 0;
+
+	while (len--) {
+		crc = *addr++ ^ crc;  // just re-using crc as intermediate
+		crc = pgm_read_byte(dscrc2x16_table + (crc & 0x0f)) ^
+		pgm_read_byte(dscrc2x16_table + 16 + ((crc >> 4) & 0x0f));
+	}
+
+	return crc;
+}
+#else
+//
+// Compute a Dallas Semiconductor 8 bit CRC directly.
+// this is much slower, but a little smaller, than the lookup table.
+//
+uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
+{
+	uint8_t crc = 0;
+
+	while (len--) {
+#if defined(__AVR__)
+		crc = _crc_ibutton_update(crc, *addr++);
+#else
+		uint8_t inbyte = *addr++;
+		for (uint8_t i = 8; i; i--) {
+			uint8_t mix = (crc ^ inbyte) & 0x01;
+			crc >>= 1;
+			if (mix) crc ^= 0x8C;
+			inbyte >>= 1;
+		}
+#endif
+	}
+	return crc;
+}
+#endif
+
+#if ONEWIRE_CRC16
+bool OneWire::check_crc16(const uint8_t* input, uint16_t len, const uint8_t* inverted_crc, uint16_t crc)
+{
+    crc = ~crc16(input, len, crc);
+    return (crc & 0xFF) == inverted_crc[0] && (crc >> 8) == inverted_crc[1];
+}
+
+uint16_t OneWire::crc16(const uint8_t* input, uint16_t len, uint16_t crc)
+{
+#if defined(__AVR__)
+    for (uint16_t i = 0 ; i < len ; i++) {
+        crc = _crc16_update(crc, input[i]);
+    }
+#else
+    static const uint8_t oddparity[16] =
+        { 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0 };
+
+    for (uint16_t i = 0 ; i < len ; i++) {
+      // Even though we're just copying a byte from the input,
+      // we'll be doing 16-bit computation with it.
+      uint16_t cdata = input[i];
+      cdata = (cdata ^ crc) & 0xff;
+      crc >>= 8;
+
+      if (oddparity[cdata & 0x0F] ^ oddparity[cdata >> 4])
+          crc ^= 0xC001;
+
+      cdata <<= 6;
+      crc ^= cdata;
+      cdata <<= 1;
+      crc ^= cdata;
+    }
+#endif
+    return crc;
+}
+#endif
+
+#endif
+
+// undef defines for no particular reason
+#ifdef ARDUINO_ARCH_ESP32
+#  undef noInterrupts() {portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;portENTER_CRITICAL(&mux)
+#  undef interrupts() portEXIT_CRITICAL(&mux);}
+#endif
+// for info on this, search "IRAM_ATTR" at https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/general-notes.html 
+#undef CRIT_TIMING 

--- a/lib/OneWire/OneWire.h
+++ b/lib/OneWire/OneWire.h
@@ -1,0 +1,182 @@
+#ifndef OneWire_h
+#define OneWire_h
+
+#ifdef __cplusplus
+
+#include <stdint.h>
+
+#if defined(__AVR__)
+#include <util/crc16.h>
+#endif
+
+#if ARDUINO >= 100
+#include <Arduino.h>       // for delayMicroseconds, digitalPinToBitMask, etc
+#else
+#include "WProgram.h"      // for delayMicroseconds
+#include "pins_arduino.h"  // for digitalPinToBitMask, etc
+#endif
+
+// You can exclude certain features from OneWire.  In theory, this
+// might save some space.  In practice, the compiler automatically
+// removes unused code (technically, the linker, using -fdata-sections
+// and -ffunction-sections when compiling, and Wl,--gc-sections
+// when linking), so most of these will not result in any code size
+// reduction.  Well, unless you try to use the missing features
+// and redesign your program to not need them!  ONEWIRE_CRC8_TABLE
+// is the exception, because it selects a fast but large algorithm
+// or a small but slow algorithm.
+
+// you can exclude onewire_search by defining that to 0
+#ifndef ONEWIRE_SEARCH
+#define ONEWIRE_SEARCH 1
+#endif
+
+// You can exclude CRC checks altogether by defining this to 0
+#ifndef ONEWIRE_CRC
+#define ONEWIRE_CRC 1
+#endif
+
+// Select the table-lookup method of computing the 8-bit CRC
+// by setting this to 1.  The lookup table enlarges code size by
+// about 250 bytes.  It does NOT consume RAM (but did in very
+// old versions of OneWire).  If you disable this, a slower
+// but very compact algorithm is used.
+#ifndef ONEWIRE_CRC8_TABLE
+#define ONEWIRE_CRC8_TABLE 1
+#endif
+
+// You can allow 16-bit CRC checks by defining this to 1
+// (Note that ONEWIRE_CRC must also be 1.)
+#ifndef ONEWIRE_CRC16
+#define ONEWIRE_CRC16 1
+#endif
+
+// Board-specific macros for direct GPIO
+#include "util/OneWire_direct_regtype.h"
+
+class OneWire
+{
+  private:
+    IO_REG_TYPE bitmask;
+    volatile IO_REG_TYPE *baseReg;
+
+#if ONEWIRE_SEARCH
+    // global search state
+    unsigned char ROM_NO[8];
+    uint8_t LastDiscrepancy;
+    uint8_t LastFamilyDiscrepancy;
+    bool LastDeviceFlag;
+#endif
+
+  public:
+    OneWire() { }
+    OneWire(uint8_t pin) { begin(pin); }
+    void begin(uint8_t pin);
+
+    // Perform a 1-Wire reset cycle. Returns 1 if a device responds
+    // with a presence pulse.  Returns 0 if there is no device or the
+    // bus is shorted or otherwise held low for more than 250uS
+    uint8_t reset(void);
+
+    // Issue a 1-Wire rom select command, you do the reset first.
+    void select(const uint8_t rom[8]);
+
+    // Issue a 1-Wire rom skip command, to address all on bus.
+    void skip(void);
+
+    // Write a byte. If 'power' is one then the wire is held high at
+    // the end for parasitically powered devices. You are responsible
+    // for eventually depowering it by calling depower() or doing
+    // another read or write.
+    void write(uint8_t v, uint8_t power = 0);
+
+    void write_bytes(const uint8_t *buf, uint16_t count, bool power = 0);
+
+    // Read a byte.
+    uint8_t read(void);
+
+    void read_bytes(uint8_t *buf, uint16_t count);
+
+    // Write a bit. The bus is always left powered at the end, see
+    // note in write() about that.
+    void write_bit(uint8_t v);
+
+    // Read a bit.
+    uint8_t read_bit(void);
+
+    // Stop forcing power onto the bus. You only need to do this if
+    // you used the 'power' flag to write() or used a write_bit() call
+    // and aren't about to do another read or write. You would rather
+    // not leave this powered if you don't have to, just in case
+    // someone shorts your bus.
+    void depower(void);
+
+#if ONEWIRE_SEARCH
+    // Clear the search state so that if will start from the beginning again.
+    void reset_search();
+
+    // Setup the search to find the device type 'family_code' on the next call
+    // to search(*newAddr) if it is present.
+    void target_search(uint8_t family_code);
+
+    // Look for the next device. Returns 1 if a new address has been
+    // returned. A zero might mean that the bus is shorted, there are
+    // no devices, or you have already retrieved all of them.  It
+    // might be a good idea to check the CRC to make sure you didn't
+    // get garbage.  The order is deterministic. You will always get
+    // the same devices in the same order.
+    bool search(uint8_t *newAddr, bool search_mode = true);
+#endif
+
+#if ONEWIRE_CRC
+    // Compute a Dallas Semiconductor 8 bit CRC, these are used in the
+    // ROM and scratchpad registers.
+    static uint8_t crc8(const uint8_t *addr, uint8_t len);
+
+#if ONEWIRE_CRC16
+    // Compute the 1-Wire CRC16 and compare it against the received CRC.
+    // Example usage (reading a DS2408):
+    //    // Put everything in a buffer so we can compute the CRC easily.
+    //    uint8_t buf[13];
+    //    buf[0] = 0xF0;    // Read PIO Registers
+    //    buf[1] = 0x88;    // LSB address
+    //    buf[2] = 0x00;    // MSB address
+    //    WriteBytes(net, buf, 3);    // Write 3 cmd bytes
+    //    ReadBytes(net, buf+3, 10);  // Read 6 data bytes, 2 0xFF, 2 CRC16
+    //    if (!CheckCRC16(buf, 11, &buf[11])) {
+    //        // Handle error.
+    //    }     
+    //          
+    // @param input - Array of bytes to checksum.
+    // @param len - How many bytes to use.
+    // @param inverted_crc - The two CRC16 bytes in the received data.
+    //                       This should just point into the received data,
+    //                       *not* at a 16-bit integer.
+    // @param crc - The crc starting value (optional)
+    // @return True, iff the CRC matches.
+    static bool check_crc16(const uint8_t* input, uint16_t len, const uint8_t* inverted_crc, uint16_t crc = 0);
+
+    // Compute a Dallas Semiconductor 16 bit CRC.  This is required to check
+    // the integrity of data received from many 1-Wire devices.  Note that the
+    // CRC computed here is *not* what you'll get from the 1-Wire network,
+    // for two reasons:
+    //   1) The CRC is transmitted bitwise inverted.
+    //   2) Depending on the endian-ness of your processor, the binary
+    //      representation of the two-byte return value may have a different
+    //      byte order than the two bytes you get from 1-Wire.
+    // @param input - Array of bytes to checksum.
+    // @param len - How many bytes to use.
+    // @param crc - The crc starting value (optional)
+    // @return The CRC16, as defined by Dallas Semiconductor.
+    static uint16_t crc16(const uint8_t* input, uint16_t len, uint16_t crc = 0);
+#endif
+#endif
+};
+
+// Prevent this name from leaking into Arduino sketches
+#ifdef IO_REG_TYPE
+#undef IO_REG_TYPE
+#endif
+
+#endif // __cplusplus
+#endif // OneWire_h

--- a/lib/OneWire/examples/DS18x20_Temperature/DS18x20_Temperature.ino
+++ b/lib/OneWire/examples/DS18x20_Temperature/DS18x20_Temperature.ino
@@ -1,0 +1,112 @@
+#include <OneWire.h>
+
+// OneWire DS18S20, DS18B20, DS1822 Temperature Example
+//
+// http://www.pjrc.com/teensy/td_libs_OneWire.html
+//
+// The DallasTemperature library can do all this work for you!
+// https://github.com/milesburton/Arduino-Temperature-Control-Library
+
+OneWire  ds(10);  // on pin 10 (a 4.7K resistor is necessary)
+
+void setup(void) {
+  Serial.begin(9600);
+}
+
+void loop(void) {
+  byte i;
+  byte present = 0;
+  byte type_s;
+  byte data[9];
+  byte addr[8];
+  float celsius, fahrenheit;
+  
+  if ( !ds.search(addr)) {
+    Serial.println("No more addresses.");
+    Serial.println();
+    ds.reset_search();
+    delay(250);
+    return;
+  }
+  
+  Serial.print("ROM =");
+  for( i = 0; i < 8; i++) {
+    Serial.write(' ');
+    Serial.print(addr[i], HEX);
+  }
+
+  if (OneWire::crc8(addr, 7) != addr[7]) {
+      Serial.println("CRC is not valid!");
+      return;
+  }
+  Serial.println();
+ 
+  // the first ROM byte indicates which chip
+  switch (addr[0]) {
+    case 0x10:
+      Serial.println("  Chip = DS18S20");  // or old DS1820
+      type_s = 1;
+      break;
+    case 0x28:
+      Serial.println("  Chip = DS18B20");
+      type_s = 0;
+      break;
+    case 0x22:
+      Serial.println("  Chip = DS1822");
+      type_s = 0;
+      break;
+    default:
+      Serial.println("Device is not a DS18x20 family device.");
+      return;
+  } 
+
+  ds.reset();
+  ds.select(addr);
+  ds.write(0x44, 1);        // start conversion, with parasite power on at the end
+  
+  delay(1000);     // maybe 750ms is enough, maybe not
+  // we might do a ds.depower() here, but the reset will take care of it.
+  
+  present = ds.reset();
+  ds.select(addr);    
+  ds.write(0xBE);         // Read Scratchpad
+
+  Serial.print("  Data = ");
+  Serial.print(present, HEX);
+  Serial.print(" ");
+  for ( i = 0; i < 9; i++) {           // we need 9 bytes
+    data[i] = ds.read();
+    Serial.print(data[i], HEX);
+    Serial.print(" ");
+  }
+  Serial.print(" CRC=");
+  Serial.print(OneWire::crc8(data, 8), HEX);
+  Serial.println();
+
+  // Convert the data to actual temperature
+  // because the result is a 16 bit signed integer, it should
+  // be stored to an "int16_t" type, which is always 16 bits
+  // even when compiled on a 32 bit processor.
+  int16_t raw = (data[1] << 8) | data[0];
+  if (type_s) {
+    raw = raw << 3; // 9 bit resolution default
+    if (data[7] == 0x10) {
+      // "count remain" gives full 12 bit resolution
+      raw = (raw & 0xFFF0) + 12 - data[6];
+    }
+  } else {
+    byte cfg = (data[4] & 0x60);
+    // at lower res, the low bits are undefined, so let's zero them
+    if (cfg == 0x00) raw = raw & ~7;  // 9 bit resolution, 93.75 ms
+    else if (cfg == 0x20) raw = raw & ~3; // 10 bit res, 187.5 ms
+    else if (cfg == 0x40) raw = raw & ~1; // 11 bit res, 375 ms
+    //// default is 12 bit resolution, 750 ms conversion time
+  }
+  celsius = (float)raw / 16.0;
+  fahrenheit = celsius * 1.8 + 32.0;
+  Serial.print("  Temperature = ");
+  Serial.print(celsius);
+  Serial.print(" Celsius, ");
+  Serial.print(fahrenheit);
+  Serial.println(" Fahrenheit");
+}

--- a/lib/OneWire/examples/DS2408_Switch/DS2408_Switch.ino
+++ b/lib/OneWire/examples/DS2408_Switch/DS2408_Switch.ino
@@ -1,0 +1,74 @@
+#include <OneWire.h>
+
+/*
+ * DS2408 8-Channel Addressable Switch
+ *
+ * Writte by Glenn Trewitt, glenn at trewitt dot org
+ *
+ * Some notes about the DS2408:
+ *   - Unlike most input/output ports, the DS2408 doesn't have mode bits to
+ *       set whether the pins are input or output.  If you issue a read command,
+ *       they're inputs.  If you write to them, they're outputs.
+ *   - For reading from a switch, you should use 10K pull-up resisters.
+ */
+
+OneWire net(10);  // on pin 10
+
+
+void PrintBytes(const uint8_t* addr, uint8_t count, bool newline=false) {
+  for (uint8_t i = 0; i < count; i++) {
+    Serial.print(addr[i]>>4, HEX);
+    Serial.print(addr[i]&0x0f, HEX);
+  }
+  if (newline)
+    Serial.println();
+}
+
+
+void setup(void) {
+  Serial.begin(9600);
+}
+
+void loop(void) {
+  byte addr[8];
+
+  if (!net.search(addr)) {
+    Serial.print("No more addresses.\n");
+    net.reset_search();
+    delay(1000);
+    return;
+  }
+
+  if (OneWire::crc8(addr, 7) != addr[7]) {
+    Serial.print("CRC is not valid!\n");
+    return;
+  }
+
+  if (addr[0] != 0x29) {
+    PrintBytes(addr, 8);
+    Serial.print(" is not a DS2408.\n");
+    return;
+  }
+
+  Serial.print("  Reading DS2408 ");
+  PrintBytes(addr, 8);
+  Serial.println();
+
+  uint8_t buf[13];  // Put everything in the buffer so we can compute CRC easily.
+  buf[0] = 0xF0;    // Read PIO Registers
+  buf[1] = 0x88;    // LSB address
+  buf[2] = 0x00;    // MSB address
+  net.write_bytes(buf, 3);
+  net.read_bytes(buf+3, 10);     // 3 cmd bytes, 6 data bytes, 2 0xFF, 2 CRC16
+  net.reset();
+
+  if (!OneWire::check_crc16(buf, 11, &buf[11])) {
+    Serial.print("CRC failure in DS2408 at ");
+    PrintBytes(addr, 8, true);
+    return;
+  }
+  Serial.print("  DS2408 data = ");
+  // First 3 bytes contain command, register address.
+  Serial.println(buf[3], BIN);
+}
+

--- a/lib/OneWire/examples/DS250x_PROM/DS250x_PROM.ino
+++ b/lib/OneWire/examples/DS250x_PROM/DS250x_PROM.ino
@@ -1,0 +1,75 @@
+/*
+DS250x add-only programmable memory reader w/SKIP ROM.
+
+ The DS250x is a 512/1024bit add-only PROM(you can add data but cannot change the old one) that's used mainly for device identification purposes
+ like serial number, mfgr data, unique identifiers, etc. It uses the Maxim 1-wire bus.
+
+ This sketch will use the SKIP ROM function that skips the 1-Wire search phase since we only have one device connected in the bus on digital pin 6.
+ If more than one device is connected to the bus, it will fail.
+ Sketch will not verify if device connected is from the DS250x family since the skip rom function effectively skips the family-id byte readout.
+ thus it is possible to run this sketch with any Maxim OneWire device in which case the command CRC will most likely fail.
+ Sketch will only read the first page of memory(32bits) starting from the lower address(0000h), if more than 1 device is present, then use the sketch with search functions.
+ Remember to put a 4.7K pullup resistor between pin 6 and +Vcc
+
+ To change the range or ammount of data to read, simply change the data array size, LSB/MSB addresses and for loop iterations
+
+ This example code is in the public domain and is provided AS-IS.
+
+ Built with Arduino 0022 and PJRC OneWire 2.0 library http://www.pjrc.com/teensy/td_libs_OneWire.html
+
+ created by Guillermo Lovato <glovato@gmail.com>
+ march/2011
+
+ */
+
+#include <OneWire.h>
+OneWire ds(6);                    // OneWire bus on digital pin 6
+void setup() {
+  Serial.begin (9600);
+}
+
+void loop() {
+  byte i;                         // This is for the for loops
+  boolean present;                // device present var
+  byte data[32];                  // container for the data from device
+  byte leemem[3] = {              // array with the commands to initiate a read, DS250x devices expect 3 bytes to start a read: command,LSB&MSB adresses
+    0xF0 , 0x00 , 0x00   };       // 0xF0 is the Read Data command, followed by 00h 00h as starting address(the beginning, 0000h)
+  byte ccrc;                      // Variable to store the command CRC
+  byte ccrc_calc;
+
+  present = ds.reset();           // OneWire bus reset, always needed to start operation on the bus, returns a 1/TRUE if there's a device present.
+  ds.skip();                      // Skip ROM search
+
+  if (present == true) {          // We only try to read the data if there's a device present
+    Serial.println("DS250x device present");
+    ds.write(leemem[0],1);        // Read data command, leave ghost power on
+    ds.write(leemem[1],1);        // LSB starting address, leave ghost power on
+    ds.write(leemem[2],1);        // MSB starting address, leave ghost power on
+
+    ccrc = ds.read();             // DS250x generates a CRC for the command we sent, we assign a read slot and store it's value
+    ccrc_calc = OneWire::crc8(leemem, 3);  // We calculate the CRC of the commands we sent using the library function and store it
+
+    if ( ccrc_calc != ccrc) {      // Then we compare it to the value the ds250x calculated, if it fails, we print debug messages and abort
+      Serial.println("Invalid command CRC!");
+      Serial.print("Calculated CRC:");
+      Serial.println(ccrc_calc,HEX);    // HEX makes it easier to observe and compare
+      Serial.print("DS250x readback CRC:");
+      Serial.println(ccrc,HEX);
+      return;                      // Since CRC failed, we abort the rest of the loop and start over
+    }
+    Serial.println("Data is: ");   // For the printout of the data
+    for ( i = 0; i < 32; i++) {    // Now it's time to read the PROM data itself, each page is 32 bytes so we need 32 read commands
+      data[i] = ds.read();         // we store each read byte to a different position in the data array
+      Serial.print(data[i]);       // printout in ASCII
+      Serial.print(" ");           // blank space
+    }
+    Serial.println();
+    delay(5000);                    // Delay so we don't saturate the serial output
+  }
+  else {                           // Nothing is connected in the bus
+    Serial.println("Nothing connected");
+    delay(3000);
+  }
+}
+
+

--- a/lib/OneWire/keywords.txt
+++ b/lib/OneWire/keywords.txt
@@ -1,0 +1,38 @@
+#######################################
+# Syntax Coloring Map For OneWire
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+OneWire	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+reset	KEYWORD2
+write_bit	KEYWORD2
+read_bit	KEYWORD2
+write	KEYWORD2
+write_bytes	KEYWORD2
+read	KEYWORD2
+read_bytes	KEYWORD2
+select	KEYWORD2
+skip	KEYWORD2
+depower	KEYWORD2
+reset_search	KEYWORD2
+search	KEYWORD2
+crc8	KEYWORD2
+crc16	KEYWORD2
+check_crc16	KEYWORD2
+
+#######################################
+# Instances (KEYWORD2)
+#######################################
+
+
+#######################################
+# Constants (LITERAL1)
+#######################################

--- a/lib/OneWire/library.json
+++ b/lib/OneWire/library.json
@@ -1,0 +1,61 @@
+{
+    "name": "OneWire",
+    "description": "Control 1-Wire protocol (DS18S20, DS18B20, DS2408 and etc) (vendored: added ESP32-C6/C5/H2 GPIO support)",
+    "keywords": "onewire, 1-wire, bus, sensor, temperature, ibutton",
+    "authors": [
+        {
+            "name": "Paul Stoffregen",
+            "email": "paul@pjrc.com",
+            "url": "http://www.pjrc.com",
+            "maintainer": true
+        },
+        {
+            "name": "Jim Studt"
+        },
+        {
+            "name": "Tom Pollard",
+            "email": "pollard@alum.mit.edu"
+        },
+        {
+            "name": "Derek Yerger"
+        },
+        {
+            "name": "Josh Larios"
+        },
+        {
+            "name": "Robin James"
+        },
+        {
+            "name": "Glenn Trewitt"
+        },
+        {
+            "name": "Jason Dangel",
+            "email": "dangel.jason AT gmail.com"
+        },
+        {
+            "name": "Guillermo Lovato"
+        },
+        {
+            "name": "Ken Butcher"
+        },
+        {
+            "name": "Mark Tillotson"
+        },
+        {
+            "name": "Bertrik Sikken"
+        },
+        {
+            "name": "Scott Roberts"
+        }
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/PaulStoffregen/OneWire"
+    },
+    "version": "2.3.8-patched-c6",
+    "homepage": "https://www.pjrc.com/teensy/td_libs_OneWire.html",
+    "frameworks": "Arduino",
+    "examples": [
+        "examples/*/*.pde"
+    ]
+}

--- a/lib/OneWire/library.properties
+++ b/lib/OneWire/library.properties
@@ -1,0 +1,10 @@
+name=OneWire
+version=2.3.8
+author=Jim Studt, Tom Pollard, Robin James, Glenn Trewitt, Jason Dangel, Guillermo Lovato, Paul Stoffregen, Scott Roberts, Bertrik Sikken, Mark Tillotson, Ken Butcher, Roger Clark, Love Nystrom
+maintainer=Paul Stoffregen
+sentence=Access 1-wire temperature sensors, memory and other chips.
+paragraph=
+category=Communication
+url=http://www.pjrc.com/teensy/td_libs_OneWire.html
+architectures=*
+

--- a/lib/OneWire/util/OneWire_direct_gpio.h
+++ b/lib/OneWire/util/OneWire_direct_gpio.h
@@ -1,0 +1,519 @@
+#ifndef OneWire_Direct_GPIO_h
+#define OneWire_Direct_GPIO_h
+
+// This header should ONLY be included by OneWire.cpp.  These defines are
+// meant to be private, used within OneWire.cpp, but not exposed to Arduino
+// sketches or other libraries which may include OneWire.h.
+
+#include <stdint.h>
+
+// Platform specific I/O definitions
+
+#if defined(__AVR__)
+#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_REG_TYPE uint8_t
+#define IO_REG_BASE_ATTR asm("r30")
+#define IO_REG_MASK_ATTR
+#if defined(__AVR_ATmega4809__)
+#define DIRECT_READ(base, mask)         (((*(base)) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   ((*((base)-8)) &= ~(mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)-8)) |= (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)-4)) &= ~(mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)-4)) |= (mask))
+#else
+#define DIRECT_READ(base, mask)         (((*(base)) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   ((*((base)+1)) &= ~(mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+1)) |= (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)+2)) &= ~(mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+2)) |= (mask))
+#endif
+
+#elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK66FX1M0__) || defined(__MK64FX512__)
+#define PIN_TO_BASEREG(pin)             (portOutputRegister(pin))
+#define PIN_TO_BITMASK(pin)             (1)
+#define IO_REG_TYPE uint8_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR __attribute__ ((unused))
+#define DIRECT_READ(base, mask)         (*((base)+512))
+#define DIRECT_MODE_INPUT(base, mask)   (*((base)+640) = 0)
+#define DIRECT_MODE_OUTPUT(base, mask)  (*((base)+640) = 1)
+#define DIRECT_WRITE_LOW(base, mask)    (*((base)+256) = 1)
+#define DIRECT_WRITE_HIGH(base, mask)   (*((base)+128) = 1)
+
+#elif defined(__MKL26Z64__)
+#define PIN_TO_BASEREG(pin)             (portOutputRegister(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_REG_TYPE uint8_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, mask)         ((*((base)+16) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   (*((base)+20) &= ~(mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  (*((base)+20) |= (mask))
+#define DIRECT_WRITE_LOW(base, mask)    (*((base)+8) = (mask))
+#define DIRECT_WRITE_HIGH(base, mask)   (*((base)+4) = (mask))
+
+#elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
+#define PIN_TO_BASEREG(pin)             (portOutputRegister(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, mask)         ((*((base)+2) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   (*((base)+1) &= ~(mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  (*((base)+1) |= (mask))
+#define DIRECT_WRITE_LOW(base, mask)    (*((base)+34) = (mask))
+#define DIRECT_WRITE_HIGH(base, mask)   (*((base)+33) = (mask))
+
+#elif defined(__SAM3X8E__) || defined(__SAM3A8C__) || defined(__SAM3A4C__)
+// Arduino 1.5.1 may have a bug in delayMicroseconds() on Arduino Due.
+// http://arduino.cc/forum/index.php/topic,141030.msg1076268.html#msg1076268
+// If you have trouble with OneWire on Arduino Due, please check the
+// status of delayMicroseconds() before reporting a bug in OneWire!
+#define PIN_TO_BASEREG(pin)             (&(digitalPinToPort(pin)->PIO_PER))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, mask)         (((*((base)+15)) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   ((*((base)+5)) = (mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+4)) = (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)+13)) = (mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+12)) = (mask))
+#ifndef PROGMEM
+#define PROGMEM
+#endif
+#ifndef pgm_read_byte
+#define pgm_read_byte(addr) (*(const uint8_t *)(addr))
+#endif
+
+#elif defined(__PIC32MX__)
+#define PIN_TO_BASEREG(pin)             (portModeRegister(digitalPinToPort(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, mask)         (((*(base+4)) & (mask)) ? 1 : 0)  //PORTX + 0x10
+#define DIRECT_MODE_INPUT(base, mask)   ((*(base+2)) = (mask))            //TRISXSET + 0x08
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*(base+1)) = (mask))            //TRISXCLR + 0x04
+#define DIRECT_WRITE_LOW(base, mask)    ((*(base+8+1)) = (mask))          //LATXCLR  + 0x24
+#define DIRECT_WRITE_HIGH(base, mask)   ((*(base+8+2)) = (mask))          //LATXSET + 0x28
+
+#elif defined(ARDUINO_ARCH_ESP8266)
+// Special note: I depend on the ESP community to maintain these definitions and
+// submit good pull requests.  I can not answer any ESP questions or help you
+// resolve any problems related to ESP chips.  Please do not contact me and please
+// DO NOT CREATE GITHUB ISSUES for ESP support.  All ESP questions must be asked
+// on ESP community forums.
+#define PIN_TO_BASEREG(pin)             ((volatile uint32_t*) GPO)
+#define PIN_TO_BITMASK(pin)             (1UL << (pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+
+static inline __attribute__((always_inline))
+void directModeInput(IO_REG_TYPE mask)
+{
+    if(mask > 0x8000)
+    {
+        GP16FFS(GPFFS_GPIO(16));
+        GPC16 = 0;
+        GP16E &= ~1;
+    }
+    else
+    {
+        GPE &= ~(mask);
+    }
+}
+
+static inline __attribute__((always_inline))
+void directModeOutput(IO_REG_TYPE mask)
+{
+    if(mask > 0x8000)
+    {
+        GP16FFS(GPFFS_GPIO(16));
+        GPC16 = 0; 
+        GP16E |= 1;
+    }
+    else
+    {
+        GPE |= (mask);
+    }
+}
+static inline __attribute__((always_inline))
+bool directRead(IO_REG_TYPE mask)
+{
+    if(mask > 0x8000)
+        return GP16I & 0x01;
+    else
+        return ((GPI & (mask)) ? true : false);
+}
+
+#define DIRECT_READ(base, mask)             directRead(mask)
+#define DIRECT_MODE_INPUT(base, mask)       directModeInput(mask)
+#define DIRECT_MODE_OUTPUT(base, mask)      directModeOutput(mask)
+#define DIRECT_WRITE_LOW(base, mask)    (mask > 0x8000) ? GP16O &= ~1 : (GPOC = (mask))
+#define DIRECT_WRITE_HIGH(base, mask)   (mask > 0x8000) ? GP16O |= 1 : (GPOS = (mask))
+
+#elif defined(ARDUINO_ARCH_ESP32)
+#include <driver/rtc_io.h>
+#include <soc/gpio_struct.h>
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+
+static inline __attribute__((always_inline))
+IO_REG_TYPE directRead(IO_REG_TYPE pin)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32H2)
+    return (GPIO.in.val >> pin) & 0x1;
+#else // plain ESP32
+    if ( pin < 32 )
+        return (GPIO.in >> pin) & 0x1;
+    else if ( pin < 46 )
+        return (GPIO.in1.val >> (pin - 32)) & 0x1;
+#endif
+
+    return 0;
+}
+
+static inline __attribute__((always_inline))
+void directWriteLow(IO_REG_TYPE pin)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32H2)
+    GPIO.out_w1tc.val = ((uint32_t)1 << pin);
+#else // plain ESP32
+    if ( pin < 32 )
+        GPIO.out_w1tc = ((uint32_t)1 << pin);
+    else if ( pin < 46 )
+        GPIO.out1_w1tc.val = ((uint32_t)1 << (pin - 32));
+#endif
+}
+
+static inline __attribute__((always_inline))
+void directWriteHigh(IO_REG_TYPE pin)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32H2)
+    GPIO.out_w1ts.val = ((uint32_t)1 << pin);
+#else // plain ESP32
+    if ( pin < 32 )
+        GPIO.out_w1ts = ((uint32_t)1 << pin);
+    else if ( pin < 46 )
+        GPIO.out1_w1ts.val = ((uint32_t)1 << (pin - 32));
+#endif
+}
+
+static inline __attribute__((always_inline))
+void directModeInput(IO_REG_TYPE pin)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32H2)
+    GPIO.enable_w1tc.val = ((uint32_t)1 << (pin));
+#else
+    if ( digitalPinIsValid(pin) )
+    {
+#if ESP_IDF_VERSION_MAJOR < 4      // IDF 3.x ESP32/PICO-D4
+        uint32_t rtc_reg(rtc_gpio_desc[pin].reg);
+
+        if ( rtc_reg ) // RTC pins PULL settings
+        {
+            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].mux);
+            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
+        }
+#endif
+	// Input
+        if ( pin < 32 )
+            GPIO.enable_w1tc = ((uint32_t)1 << pin);
+        else
+            GPIO.enable1_w1tc.val = ((uint32_t)1 << (pin - 32));
+    }
+#endif
+}
+
+static inline __attribute__((always_inline))
+void directModeOutput(IO_REG_TYPE pin)
+{
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32H2)
+    GPIO.enable_w1ts.val = ((uint32_t)1 << (pin));
+#else
+    if ( digitalPinIsValid(pin) && pin <= 33 ) // pins above 33 can be only inputs
+    {
+#if ESP_IDF_VERSION_MAJOR < 4      // IDF 3.x ESP32/PICO-D4
+        uint32_t rtc_reg(rtc_gpio_desc[pin].reg);
+
+        if ( rtc_reg ) // RTC pins PULL settings
+        {
+            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].mux);
+            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
+        }
+#endif
+        // Output
+        if ( pin < 32 )
+            GPIO.enable_w1ts = ((uint32_t)1 << pin);
+        else // already validated to pins <= 33
+            GPIO.enable1_w1ts.val = ((uint32_t)1 << (pin - 32));
+    }
+#endif
+}
+
+#define DIRECT_READ(base, pin)          directRead(pin)
+#define DIRECT_WRITE_LOW(base, pin)     directWriteLow(pin)
+#define DIRECT_WRITE_HIGH(base, pin)    directWriteHigh(pin)
+#define DIRECT_MODE_INPUT(base, pin)    directModeInput(pin)
+#define DIRECT_MODE_OUTPUT(base, pin)   directModeOutput(pin)
+// https://github.com/PaulStoffregen/OneWire/pull/47
+// https://github.com/stickbreaker/OneWire/commit/6eb7fc1c11a15b6ac8c60e5671cf36eb6829f82c
+#ifdef  interrupts
+#undef  interrupts
+#endif
+#ifdef  noInterrupts
+#undef  noInterrupts
+#endif
+#define noInterrupts() {portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;portENTER_CRITICAL(&mux)
+#define interrupts() portEXIT_CRITICAL(&mux);}
+//#warning "ESP32 OneWire testing"
+
+#elif defined(ARDUINO_ARCH_STM32)
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             ((uint32_t)digitalPinToPinName(pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          digitalReadFast((PinName)pin)
+#define DIRECT_WRITE_LOW(base, pin)     digitalWriteFast((PinName)pin, LOW)
+#define DIRECT_WRITE_HIGH(base, pin)    digitalWriteFast((PinName)pin, HIGH)
+#define DIRECT_MODE_INPUT(base, pin)    pin_function((PinName)pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0))
+#define DIRECT_MODE_OUTPUT(base, pin)   pin_function((PinName)pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0))
+
+#elif defined(__SAMD21G18A__)
+#define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, mask)         (((*((base)+8)) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   ((*((base)+1)) = (mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+2)) = (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)+5)) = (mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+6)) = (mask))
+
+#elif defined(__ASR6501__)
+#define PIN_IN_PORT(pin)    (pin % PIN_NUMBER_IN_PORT)
+#define PORT_FROM_PIN(pin)  (pin / PIN_NUMBER_IN_PORT)
+#define PORT_OFFSET(port)   (PORT_REG_SHFIT * port)
+#define PORT_ADDRESS(pin)   (CYDEV_GPIO_BASE + PORT_OFFSET(PORT_FROM_PIN(pin)))
+
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          CY_SYS_PINS_READ_PIN(PORT_ADDRESS(pin)+4, PIN_IN_PORT(pin))
+#define DIRECT_WRITE_LOW(base, pin)     CY_SYS_PINS_CLEAR_PIN(PORT_ADDRESS(pin), PIN_IN_PORT(pin))
+#define DIRECT_WRITE_HIGH(base, pin)    CY_SYS_PINS_SET_PIN(PORT_ADDRESS(pin), PIN_IN_PORT(pin))
+#define DIRECT_MODE_INPUT(base, pin)    CY_SYS_PINS_SET_DRIVE_MODE(PORT_ADDRESS(pin)+8, PIN_IN_PORT(pin), CY_SYS_PINS_DM_DIG_HIZ)
+#define DIRECT_MODE_OUTPUT(base, pin)   CY_SYS_PINS_SET_DRIVE_MODE(PORT_ADDRESS(pin)+8, PIN_IN_PORT(pin), CY_SYS_PINS_DM_STRONG)
+
+#elif defined(RBL_NRF51822)
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          nrf_gpio_pin_read(pin)
+#define DIRECT_WRITE_LOW(base, pin)     nrf_gpio_pin_clear(pin)
+#define DIRECT_WRITE_HIGH(base, pin)    nrf_gpio_pin_set(pin)
+#define DIRECT_MODE_INPUT(base, pin)    nrf_gpio_cfg_input(pin, NRF_GPIO_PIN_NOPULL)
+#define DIRECT_MODE_OUTPUT(base, pin)   nrf_gpio_cfg_output(pin)
+
+#elif defined(__arc__) /* Arduino101/Genuino101 specifics */
+
+#include "scss_registers.h"
+#include "portable.h"
+#include "avr/pgmspace.h"
+
+#define GPIO_ID(pin)			(g_APinDescription[pin].ulGPIOId)
+#define GPIO_TYPE(pin)			(g_APinDescription[pin].ulGPIOType)
+#define GPIO_BASE(pin)			(g_APinDescription[pin].ulGPIOBase)
+#define DIR_OFFSET_SS			0x01
+#define DIR_OFFSET_SOC			0x04
+#define EXT_PORT_OFFSET_SS		0x0A
+#define EXT_PORT_OFFSET_SOC		0x50
+
+/* GPIO registers base address */
+#define PIN_TO_BASEREG(pin)		((volatile uint32_t *)g_APinDescription[pin].ulGPIOBase)
+#define PIN_TO_BITMASK(pin)		pin
+#define IO_REG_TYPE			uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+
+static inline __attribute__((always_inline))
+IO_REG_TYPE directRead(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    IO_REG_TYPE ret;
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        ret = READ_ARC_REG(((IO_REG_TYPE)base + EXT_PORT_OFFSET_SS));
+    } else {
+        ret = MMIO_REG_VAL_FROM_BASE((IO_REG_TYPE)base, EXT_PORT_OFFSET_SOC);
+    }
+    return ((ret >> GPIO_ID(pin)) & 0x01);
+}
+
+static inline __attribute__((always_inline))
+void directModeInput(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG((((IO_REG_TYPE)base) + DIR_OFFSET_SS)) & ~(0x01 << GPIO_ID(pin)),
+			((IO_REG_TYPE)(base) + DIR_OFFSET_SS));
+    } else {
+        MMIO_REG_VAL_FROM_BASE((IO_REG_TYPE)base, DIR_OFFSET_SOC) &= ~(0x01 << GPIO_ID(pin));
+    }
+}
+
+static inline __attribute__((always_inline))
+void directModeOutput(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG(((IO_REG_TYPE)(base) + DIR_OFFSET_SS)) | (0x01 << GPIO_ID(pin)),
+			((IO_REG_TYPE)(base) + DIR_OFFSET_SS));
+    } else {
+        MMIO_REG_VAL_FROM_BASE((IO_REG_TYPE)base, DIR_OFFSET_SOC) |= (0x01 << GPIO_ID(pin));
+    }
+}
+
+static inline __attribute__((always_inline))
+void directWriteLow(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG(base) & ~(0x01 << GPIO_ID(pin)), base);
+    } else {
+        MMIO_REG_VAL(base) &= ~(0x01 << GPIO_ID(pin));
+    }
+}
+
+static inline __attribute__((always_inline))
+void directWriteHigh(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG(base) | (0x01 << GPIO_ID(pin)), base);
+    } else {
+        MMIO_REG_VAL(base) |= (0x01 << GPIO_ID(pin));
+    }
+}
+
+#define DIRECT_READ(base, pin)		directRead(base, pin)
+#define DIRECT_MODE_INPUT(base, pin)	directModeInput(base, pin)
+#define DIRECT_MODE_OUTPUT(base, pin)	directModeOutput(base, pin)
+#define DIRECT_WRITE_LOW(base, pin)	directWriteLow(base, pin)
+#define DIRECT_WRITE_HIGH(base, pin)	directWriteHigh(base, pin)
+
+#elif defined(__riscv)
+
+/*
+ * Tested on highfive1
+ *
+ * Stable results are achieved operating in the
+ * two high speed modes of the highfive1.  It
+ * seems to be less reliable in slow mode.
+ */
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             digitalPinToBitMask(pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+
+static inline __attribute__((always_inline))
+IO_REG_TYPE directRead(IO_REG_TYPE mask)
+{
+    return ((GPIO_REG(GPIO_INPUT_VAL) & mask) != 0) ? 1 : 0;
+}
+
+static inline __attribute__((always_inline))
+void directModeInput(IO_REG_TYPE mask)
+{
+    GPIO_REG(GPIO_OUTPUT_XOR)  &= ~mask;
+    GPIO_REG(GPIO_IOF_EN)      &= ~mask;
+
+    GPIO_REG(GPIO_INPUT_EN)  |=  mask;
+    GPIO_REG(GPIO_OUTPUT_EN) &= ~mask;
+}
+
+static inline __attribute__((always_inline))
+void directModeOutput(IO_REG_TYPE mask)
+{
+    GPIO_REG(GPIO_OUTPUT_XOR)  &= ~mask;
+    GPIO_REG(GPIO_IOF_EN)      &= ~mask;
+
+    GPIO_REG(GPIO_INPUT_EN)  &= ~mask;
+    GPIO_REG(GPIO_OUTPUT_EN) |=  mask;
+}
+
+static inline __attribute__((always_inline))
+void directWriteLow(IO_REG_TYPE mask)
+{
+    GPIO_REG(GPIO_OUTPUT_VAL) &= ~mask;
+}
+
+static inline __attribute__((always_inline))
+void directWriteHigh(IO_REG_TYPE mask)
+{
+    GPIO_REG(GPIO_OUTPUT_VAL) |= mask;
+}
+
+#define DIRECT_READ(base, mask)          directRead(mask)
+#define DIRECT_WRITE_LOW(base, mask)     directWriteLow(mask)
+#define DIRECT_WRITE_HIGH(base, mask)    directWriteHigh(mask)
+#define DIRECT_MODE_INPUT(base, mask)    directModeInput(mask)
+#define DIRECT_MODE_OUTPUT(base, mask)   directModeOutput(mask)
+
+#elif defined(__MBED__)
+
+#include "platform/mbed_critical.h"
+#include "DigitalInOut.h"
+#include <cmsis_os2.h>
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (new mbed::DigitalInOut(digitalPinToPinName(pin)))
+#define IO_REG_TYPE                     mbed::DigitalInOut*
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          (*pin)
+#define DIRECT_WRITE_LOW(base, pin)     (*pin = 0)
+#define DIRECT_WRITE_HIGH(base, pin)    (*pin = 1)
+#define DIRECT_MODE_INPUT(base, pin)    (pin->input())
+#define DIRECT_MODE_OUTPUT(base, pin)   (pin->output())
+#undef interrupts
+#undef noInterrupts
+#define noInterrupts()                  osThreadSetPriority(osThreadGetId(), osPriorityRealtime) //core_util_critical_section_enter()
+#define interrupts()                    osThreadSetPriority(osThreadGetId(), osPriorityNormal) //core_util_critical_section_exit()
+
+#elif defined(ARDUINO_ARCH_MBED_RP2040)|| defined(ARDUINO_ARCH_RP2040)
+#define delayMicroseconds(time)         busy_wait_us(time)
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE unsigned int
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          digitalRead(pin)
+#define DIRECT_WRITE_LOW(base, pin)     digitalWrite(pin, LOW)
+#define DIRECT_WRITE_HIGH(base, pin)    digitalWrite(pin, HIGH)
+#define DIRECT_MODE_INPUT(base, pin)    pinMode(pin,INPUT)
+#define DIRECT_MODE_OUTPUT(base, pin)   pinMode(pin,OUTPUT)
+#warning "OneWire. RP2040 in Fallback mode. Using API calls for pinMode,digitalRead and digitalWrite."
+
+#else
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE unsigned int
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          digitalRead(pin)
+#define DIRECT_WRITE_LOW(base, pin)     digitalWrite(pin, LOW)
+#define DIRECT_WRITE_HIGH(base, pin)    digitalWrite(pin, HIGH)
+#define DIRECT_MODE_INPUT(base, pin)    pinMode(pin,INPUT)
+#define DIRECT_MODE_OUTPUT(base, pin)   pinMode(pin,OUTPUT)
+#warning "OneWire. Fallback mode. Using API calls for pinMode,digitalRead and digitalWrite. Operation of this library is not guaranteed on this architecture."
+
+#endif
+
+#endif

--- a/lib/OneWire/util/OneWire_direct_regtype.h
+++ b/lib/OneWire/util/OneWire_direct_regtype.h
@@ -1,0 +1,59 @@
+#ifndef OneWire_Direct_RegType_h
+#define OneWire_Direct_RegType_h
+
+#include <stdint.h>
+
+// Platform specific I/O register type
+
+#if defined(__AVR__)
+#define IO_REG_TYPE uint8_t
+
+#elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK66FX1M0__) || defined(__MK64FX512__)
+#define IO_REG_TYPE uint8_t
+
+#elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(__MKL26Z64__)
+#define IO_REG_TYPE uint8_t
+
+#elif defined(__SAM3X8E__) || defined(__SAM3A8C__) || defined(__SAM3A4C__)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(__PIC32MX__)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(ARDUINO_ARCH_ESP8266)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(ARDUINO_ARCH_ESP32)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_MASK_ATTR
+
+#elif defined(ARDUINO_ARCH_STM32)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(__SAMD21G18A__)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(__ASR6501__)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(RBL_NRF51822)
+#define IO_REG_TYPE uint32_t
+
+#elif defined(__arc__) /* Arduino101/Genuino101 specifics */
+#define IO_REG_TYPE uint32_t
+
+#elif defined(__MBED__)
+#include "DigitalInOut.h"
+#define IO_REG_TYPE mbed::DigitalInOut*
+
+#elif defined(__riscv)
+#define IO_REG_TYPE uint32_t
+
+#else
+#define IO_REG_TYPE unsigned int
+
+#endif
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,10 +32,13 @@ build_flags =
   -D INFRARED_IREMOTE_ESP8266 ; Use IRremoteESP8266 as infrared lib
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
   ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Linux users can uncomment this line
-lib_deps =
+; Shared library deps, WITHOUT the SPI slave client. ESP32SPISlave is pinned
+; per chip family because upstream <= 0.6.9 references SPI3_HOST unconditionally
+; for HSPI, which does not exist on the single-SPI-host ESP32-C6 (SOC_SPI_PERIPH_NUM == 2).
+; Upstream fixed it in v0.8.0 (commit 52cce66 "feat: support ESP32-C5, C6, H2, P4").
+lib_deps_base =
   fastled/FastLED@^3.3.3
   bblanchon/ArduinoJson@^7.3.0
-  hideakitai/ESP32SPISlave@^0.6.8
   gilman88/XModem@^1.0.3
   ewpa/LibSSH-ESP32@^5.6.0
   autowp/autowp-mcp2515@^1.2.1
@@ -43,6 +46,9 @@ lib_deps =
   miq19/eModbus@^1.7.4
   pstolarz/OneWireNg@^0.14.0
   adafruit/Adafruit Si4713 Library@^1.2.3
+lib_deps =
+  ${env.lib_deps_base}
+  hideakitai/ESP32SPISlave@^0.6.8
 
 
 ; =========================================================
@@ -1947,10 +1953,12 @@ test_framework = unity
 [env:c6-devkit]
 board = esp32-c6-devkitm-1
 board_upload.flash_size = 8MB
-board_upload.flash_size = 8MB
+; ESP32-C6 override: needs ESP32SPISlave >= 0.8.0 (upstream fix for SPI3_HOST
+; on single-SPI-host targets). S3 boards keep the registry ^0.6.8 from [env].
 lib_deps =
   crankyoldgit/IRremoteESP8266 @ ^2.9.0
-  ${env.lib_deps}
+  ${env.lib_deps_base}
+  ESP32SPISlave=https://github.com/hideakitai/ESP32SPISlave.git#v0.8.0
 build_flags =
   -Isrc/Boards/Common
   ; C6 uses USB Serial/JTAG (no OTG/TinyUSB like the S3 boards)

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; PlatformIO Project Configuration File
+﻿; PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags
@@ -13,7 +13,6 @@
 ; Global shared configuration
 ; =========================================================
 [env]
-board_build.partitions = partitions/app4M_spiffs_4M_8MB.csv
 ; Temporary workaround: do not point to latest stable to avoid higher RAM usage
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 framework = arduino
@@ -683,7 +682,6 @@ build_flags =
 ; =========================================================
 [env:s3-devkit-n16-r8]
 board = esp32-s3-devkitc1-n16r8
-board_build.partitions = partitions/app4M_spiffs_12M_16MB.csv
 lib_deps =
   crankyoldgit/IRremoteESP8266 @ ^2.9.0
   ${env.lib_deps}
@@ -1007,7 +1005,6 @@ build_flags =
 ; =========================================================
 [env:t-display-s3]
 board = esp32-s3-devkitc1-n16r8
-board_build.partitions = partitions/app4M_spiffs_12M_16MB.csv
 lib_deps =
   LovyanGFX=https://github.com/lovyan03/LovyanGFX
   crankyoldgit/IRremoteESP8266 @ ^2.9.0
@@ -1120,7 +1117,6 @@ build_flags =
 ; =========================================================
 [env:waveshare-s3-geek]
 board = esp32-s3-devkitc1-n16r2
-board_build.partitions = partitions/app4M_spiffs_12M_16MB.csv
 lib_deps =
   LovyanGFX=https://github.com/lovyan03/LovyanGFX
   crankyoldgit/IRremoteESP8266 @ ^2.9.0
@@ -1608,7 +1604,6 @@ build_flags =
 ; =========================================================
 [env:vision-master-t190]
 board = esp32-s3-devkitc1-n16r8
-board_build.partitions = partitions/app4M_spiffs_12M_16MB.csv
 lib_deps =
   LovyanGFX=https://github.com/lovyan03/LovyanGFX
   crankyoldgit/IRremoteESP8266 @ ^2.9.0
@@ -1717,7 +1712,6 @@ build_flags =
 ; =========================================================
 [env:heltec_wifi_lora_32_V4]
 board = esp32-s3-devkitc1-n16r2
-board_build.partitions = partitions/app4M_spiffs_12M_16MB.csv
 upload_speed = 921600
 lib_deps =
   crankyoldgit/IRremoteESP8266 @ ^2.9.0
@@ -1833,7 +1827,7 @@ build_flags =
 
 
 ; =========================================================
-; Heltec WiFi LoRa 32 V3 (CP210x UART — not native USB-CDC)
+; Heltec WiFi LoRa 32 V3 (CP210x UART â€” not native USB-CDC)
 ; =========================================================
 [env:heltec_wifi_lora_32_V3]
 board = heltec_wifi_lora_32_V3
@@ -1857,7 +1851,7 @@ build_flags =
   -DDEVICE_S3DEVKIT
   -DDEVICE_HOST_SERIAL_UART
 
-  ; OLED 17/18/21, LoRa 8–14, flash 33–38, Vext 36, USB 43/44
+  ; OLED 17/18/21, LoRa 8â€“14, flash 33â€“38, Vext 36, USB 43/44
   ; SWD probe defaults: 4=SWDIO, 5=SWCLK, 6=RST, 1=UART RX
   -DPROTECTED_PINS="\"0, 1, 4, 5, 6, 17, 18, 21, 33, 34, 35, 36, 37, 38, 43, 44\""
 
@@ -1944,3 +1938,119 @@ lib_deps =
   throwtheswitch/Unity@^2.6.1
 test_build_src = no
 test_framework = unity
+
+
+; =========================================================
+; ESP32-C6 DevKitM-1 - WiFi tool board (no Zigbee: radio is reserved
+; for the Bus Expander firmware, see geo-tp/ESP32-Bus-Expander)
+; =========================================================
+[env:c6-devkit]
+board = esp32-c6-devkitm-1
+board_upload.flash_size = 8MB
+board_upload.flash_size = 8MB
+lib_deps =
+  crankyoldgit/IRremoteESP8266 @ ^2.9.0
+  ${env.lib_deps}
+build_flags =
+  -Isrc/Boards/Common
+  ; C6 uses USB Serial/JTAG (no OTG/TinyUSB like the S3 boards)
+  -D ARDUINO_USB_MODE=1
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -Wl,-zmuldefs ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth
+  -D INFRARED_IREMOTE_ESP8266 ; Use IRremoteESP8266 as infrared lib
+  -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
+  -D DEVICE_C6DEVKIT
+
+  ; --- Pin in use ---
+  ; USB Serial/JTAG 12/13, console UART0 16/17, strapping 8/9/14/15, internal flash 24-30
+  -DPROTECTED_PINS="\"8, 9, 12, 13, 14, 15, 16, 17, 24, 25, 26, 27, 28, 29, 30\""
+
+  ; --- Builtin LED ---
+  -DLED_PIN=8
+  -DLED_TYPE_RGB=true
+
+  ; --- OneWire ---
+  -DONEWIRE_PIN=0
+
+  ; --- UART ---
+  -DUART_BAUD=9600
+  -DUART_RX_PIN=18
+  -DUART_TX_PIN=19
+
+  ; --- HDUART ---
+  -DHDUART_BAUD=9600
+  -DHDUART_PIN=10
+
+  ; --- I2C ---
+  -DI2C_SCL_PIN=20
+  -DI2C_SDA_PIN=21
+  -DI2C_FREQ=100000
+
+  ; --- SPI ---
+  -DSPI_CS_PIN=22
+  -DSPI_CLK_PIN=23
+  -DSPI_MISO_PIN=2
+  -DSPI_MOSI_PIN=3
+
+  ; --- LoRa SX1262 ---
+  -DLORA_SCK_PIN=23 -DLORA_MISO_PIN=2 -DLORA_MOSI_PIN=3 -DLORA_CS_PIN=22
+  -DLORA_RST_PIN=4 -DLORA_BUSY_PIN=5 -DLORA_DIO1_PIN=6
+
+  ; --- Infrared ---
+  -DIR_TX_PIN=7
+  -DIR_RX_PIN=11
+
+  ; --- LED ---
+  -DLED_DATA_PIN=20
+  -DLED_CLOCK_PIN=21
+
+  ; --- TwoWire ---
+  -DTWOWIRE_CLK_PIN=11
+  -DTWOWIRE_IO_PIN=2
+  -DTWOWIRE_RST_PIN=3
+
+  ; --- ThreeWire ---
+  -DTHREEWIRE_CS_PIN=10
+  -DTHREEWIRE_SK_PIN=11
+  -DTHREEWIRE_DI_PIN=2
+  -DTHREEWIRE_DO_PIN=3
+
+  ; --- I2S ---
+  -DI2S_BCLK_PIN=18
+  -DI2S_LRCK_PIN=19
+  -DI2S_DATA_PIN=21
+  -DI2S_SAMPLE_RATE=16000
+  -DI2S_BITS=16
+
+  ; --- CAN ---
+  -DCAN_CS_PIN=6
+  -DCAN_SCK_PIN=7
+  -DCAN_SI_PIN=2
+  -DCAN_SO_PIN=3
+  -DCAN_KBPS=125
+
+  ; --- ETHERNET (W5500) ---
+  -DETHERNET_CS_PIN=6
+  -DETHERNET_CLK_PIN=7
+  -DETHERNET_MISO_PIN=3
+  -DETHERNET_MOSI_PIN=2
+  -DETHERNET_IRQ_PIN=10
+
+  ; --- SUBGHZ ---
+  -DSUBGHZ_CS_PIN=4
+  -DSUBGHZ_SCK_PIN=5
+  -DSUBGHZ_SI_PIN=6
+  -DSUBGHZ_SO_PIN=7
+  -DSUBGHZ_GDO_PIN=10
+
+  ; --- RF24 ---
+  -DRF24_CSN_PIN=4
+  -DRF24_CE_PIN=10
+  -DRF24_SCK_PIN=5
+  -DRF24_MISO_PIN=7
+  -DRF24_MOSI_PIN=6
+
+  ; --- JTAG ---
+  -DJTAG_SCAN_PINS="\"4, 5, 6, 7\""
+
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,6 @@ build_flags =
 lib_deps =
   fastled/FastLED@^3.3.3
   bblanchon/ArduinoJson@^7.3.0
-  paulstoffregen/OneWire@^2.3.8
   hideakitai/ESP32SPISlave@^0.6.8
   gilman88/XModem@^1.0.3
   ewpa/LibSSH-ESP32@^5.6.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-﻿; PlatformIO Project Configuration File
+; PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags
@@ -13,6 +13,7 @@
 ; Global shared configuration
 ; =========================================================
 [env]
+board_build.partitions = partitions/app4M_spiffs_4M_8MB.csv
 ; Temporary workaround: do not point to latest stable to avoid higher RAM usage
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 framework = arduino
@@ -1833,7 +1834,7 @@ build_flags =
 
 
 ; =========================================================
-; Heltec WiFi LoRa 32 V3 (CP210x UART â€” not native USB-CDC)
+; Heltec WiFi LoRa 32 V3 (CP210x UART Ã¢â‚¬â€ not native USB-CDC)
 ; =========================================================
 [env:heltec_wifi_lora_32_V3]
 board = heltec_wifi_lora_32_V3
@@ -1857,7 +1858,7 @@ build_flags =
   -DDEVICE_S3DEVKIT
   -DDEVICE_HOST_SERIAL_UART
 
-  ; OLED 17/18/21, LoRa 8â€“14, flash 33â€“38, Vext 36, USB 43/44
+  ; OLED 17/18/21, LoRa 8Ã¢â‚¬â€œ14, flash 33Ã¢â‚¬â€œ38, Vext 36, USB 43/44
   ; SWD probe defaults: 4=SWDIO, 5=SWCLK, 6=RST, 1=UART RX
   -DPROTECTED_PINS="\"0, 1, 4, 5, 6, 17, 18, 21, 33, 34, 35, 36, 37, 38, 43, 44\""
 

--- a/src/Adapters/FlashromSerprogAdapter.cpp
+++ b/src/Adapters/FlashromSerprogAdapter.cpp
@@ -147,6 +147,20 @@ void FlashromSerprogAdapter::onUsbEvent(void* arg, esp_event_base_t eventBase, i
     (void)eventBase;
     (void)eventData;
 
+#if ARDUINO_USB_MODE
+    if (eventId == ARDUINO_HW_CDC_CONNECTED_EVENT) {
+        cdcConnected = true;
+        resetSpiBusState();
+        purgeInput();
+        return;
+    }
+
+    if (eventId == ARDUINO_HW_CDC_BUS_RESET_EVENT) {
+        cdcConnected = false;
+        resetSpiBusState();
+        purgeInput();
+    }
+#else
     if (eventId == ARDUINO_USB_CDC_CONNECTED_EVENT) {
         cdcConnected = true;
         resetSpiBusState();
@@ -159,6 +173,7 @@ void FlashromSerprogAdapter::onUsbEvent(void* arg, esp_event_base_t eventBase, i
         resetSpiBusState();
         purgeInput();
     }
+#endif
 }
 
 void FlashromSerprogAdapter::handleCommand(uint8_t command, IInput& input) {

--- a/src/Adapters/InfraredToyAdapter.h
+++ b/src/Adapters/InfraredToyAdapter.h
@@ -96,20 +96,28 @@ private:
     static uint16_t popRxDuration();
 
     static inline uint8_t fastReadPin(uint8_t pin) {
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32H2)
+        return (GPIO.in.val >> pin) & 0x1;
+#else
         if (pin < 32) {
             return (GPIO.in >> pin) & 0x1;
         }
 
         return (GPIO.in1.val >> (pin - 32)) & 0x1;
+#endif
     }
 
     static inline void fastWritePinLow(uint8_t pin) {
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32H2)
+        GPIO.out_w1tc.val = (1UL << pin);
+#else
         if (pin < 32) {
             GPIO.out_w1tc = (1UL << pin);
             return;
         }
 
         GPIO.out1_w1tc.val = (1UL << (pin - 32));
+#endif
     }
 
     static inline InfraredToyConfig config = {0, 0};

--- a/src/Adapters/UsbUartBridgeAdapter.cpp
+++ b/src/Adapters/UsbUartBridgeAdapter.cpp
@@ -66,6 +66,7 @@ void UsbUartBridgeAdapter::configureUart(unsigned long baudRate, uint32_t uartCo
     );
 }
 
+#if !ARDUINO_USB_MODE
 void UsbUartBridgeAdapter::onLineCoding(void* arg, esp_event_base_t eventBase, int32_t eventId, void* eventData) {
     (void)arg;
     (void)eventBase;
@@ -84,6 +85,7 @@ void UsbUartBridgeAdapter::onLineCoding(void* arg, esp_event_base_t eventBase, i
 
     configureUart(data->line_coding.bit_rate, uartConfig);
 }
+#endif
 
 void UsbUartBridgeAdapter::pumpUartToUsb() {
     uint8_t buffer[BRIDGE_CHUNK_SIZE];
@@ -154,7 +156,7 @@ void UsbUartBridgeAdapter::run(const UsbUartBridgeConfig& config, IInput& input,
     hostSerial->disableReboot();
     hostSerial->setRxBufferSize(USB_RX_BUFFER_SIZE);
     hostSerial->setTimeout(0);
-#if ARDUINO_USB_CDC_ON_BOOT
+#if !ARDUINO_USB_MODE && ARDUINO_USB_CDC_ON_BOOT
     Serial.onEvent(ARDUINO_USB_CDC_LINE_CODING_EVENT, onLineCoding);
 #endif
     hostSerial->begin(DEFAULT_BAUD);

--- a/src/Boards/C6DevKit/C6DevKitBoard.cpp
+++ b/src/Boards/C6DevKit/C6DevKitBoard.cpp
@@ -1,0 +1,21 @@
+#ifdef DEVICE_C6DEVKIT
+
+#include "Boards/C6DevKit/C6DevKitBoard.h"
+
+void C6DevKitBoard::initialize() {
+    deviceView.initialize();
+}
+
+IDeviceView& C6DevKitBoard::getDeviceView() {
+    return deviceView;
+}
+
+IInput& C6DevKitBoard::getDeviceInput() {
+    return deviceInput;
+}
+
+IHostSerial& C6DevKitBoard::getHostSerial() {
+    return hostSerial;
+}
+
+#endif

--- a/src/Boards/C6DevKit/C6DevKitBoard.h
+++ b/src/Boards/C6DevKit/C6DevKitBoard.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef DEVICE_C6DEVKIT
+
+#include "Boards/Common/Views/NoScreenDeviceView.h"
+#include "Boards/Common/Inputs/DefaultInput.h"
+#include "Boards/Common/Serial/BoardHostSerial.h"
+
+class C6DevKitBoard final {
+public:
+    void initialize();
+    IDeviceView& getDeviceView();
+    IInput& getDeviceInput();
+    IHostSerial& getHostSerial();
+
+private:
+    BoardHostSerial hostSerial;
+    NoScreenDeviceView deviceView;
+    DefaultInput deviceInput;
+};
+
+#endif

--- a/src/Boards/Common/Serial/DefaultHostSerial.h
+++ b/src/Boards/Common/Serial/DefaultHostSerial.h
@@ -71,7 +71,7 @@ public:
     }
 
     void disableReboot() override {
-#if ARDUINO_USB_CDC_ON_BOOT
+#if !ARDUINO_USB_MODE && ARDUINO_USB_CDC_ON_BOOT
         Serial.enableReboot(false);
 #endif
     }

--- a/src/Boards/Common/Wifi/DefaultWifiSetup.cpp
+++ b/src/Boards/Common/Wifi/DefaultWifiSetup.cpp
@@ -1,4 +1,4 @@
-#if defined(DEVICE_M5STAMPS3) || defined(DEVICE_S3DEVKIT) || defined(DEVICE_VISION_MASTER_T190) || defined(DEVICE_CUSTOM)
+#if defined(DEVICE_M5STAMPS3) || defined(DEVICE_S3DEVKIT) || defined(DEVICE_VISION_MASTER_T190) || defined(DEVICE_CUSTOM) || defined(DEVICE_C6DEVKIT)
 
 #include "Boards/Common/Wifi/DefaultWifiSetup.h"
 #include <Preferences.h>

--- a/src/Boards/Common/Wifi/DefaultWifiSetup.h
+++ b/src/Boards/Common/Wifi/DefaultWifiSetup.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(DEVICE_M5STAMPS3) || defined(DEVICE_S3DEVKIT) || defined(DEVICE_VISION_MASTER_T190) || defined(DEVICE_CUSTOM)
+#if defined(DEVICE_M5STAMPS3) || defined(DEVICE_S3DEVKIT) || defined(DEVICE_VISION_MASTER_T190) || defined(DEVICE_CUSTOM) || defined(DEVICE_C6DEVKIT)
 
 bool setupDefaultWifi();
 

--- a/src/Services/HdUartService.cpp
+++ b/src/Services/HdUartService.cpp
@@ -161,7 +161,13 @@ uart_config_t HdUartService::buildUartConfig(unsigned long baud, uint8_t bits, c
         .parity = parityMode,
         .stop_bits = stopBits,
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        // ESP32-C6 has no APB clock source for UART; PLL_F80M is its equivalent
+        // fast clock. Other targets keep the legacy APB source.
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+        .source_clk = UART_SCLK_PLL_F80M
+#else
         .source_clk = UART_SCLK_APB
+#endif
     };
 
     return config;

--- a/src/Services/HdUartService.h
+++ b/src/Services/HdUartService.h
@@ -10,7 +10,14 @@
 #include "Models/ByteCode.h"
 #include "Interfaces/IHdUartService.h"
 
+// ESP32-C6 exposes only two HP UARTs (SOC_UART_HP_NUM == 2, its third
+// SOC_UART_NUM entry is the LP_UART), so fall back to UART1 there.
+// Targets with three HP UARTs (e.g. ESP32-S3) keep using UART2.
+#if SOC_UART_HP_NUM > 2
 #define HD_UART_PORT UART_NUM_2
+#else
+#define HD_UART_PORT UART_NUM_1
+#endif
 #define UART_RX_BUFFER_SIZE 256
 
 class HdUartService : public IHdUartService {

--- a/src/Services/SystemService.cpp
+++ b/src/Services/SystemService.cpp
@@ -11,7 +11,14 @@
 #include <nvs.h>
 #include <esp_mac.h>
 #include "soc/soc.h"
+// The forced-download-boot latch moved between peripherals depending on the
+// target: classic chips keep it in RTC_CNTL (rtc_cntl_reg.h), while the
+// ESP32-C6 has no rtc_cntl_reg.h at all and exposes it via LP_AON.
+#if CONFIG_IDF_TARGET_ESP32C6
+#include "soc/lp_aon_reg.h"
+#else
 #include "soc/rtc_cntl_reg.h"
+#endif
 #include "esp_image_format.h"
 
 namespace {
@@ -398,7 +405,13 @@ void SystemService::reboot(bool hard) const {
 }
 
 void SystemService::rebootToBootloader() const {
+#if CONFIG_IDF_TARGET_ESP32C6
+    // ESP32-C6: the forced download boot bit lives in LP_AON SYS_CFG
+    // (bit 30, LP_AON_FORCE_DOWNLOAD_BOOT); there is no RTC_CNTL_OPTION1_REG.
+    REG_WRITE(LP_AON_SYS_CFG_REG, LP_AON_FORCE_DOWNLOAD_BOOT);
+#else
     REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+#endif
     delay(100);
     esp_restart();
 }

--- a/src/Services/UsbS3Service.cpp
+++ b/src/Services/UsbS3Service.cpp
@@ -1,5 +1,10 @@
 #include "UsbS3Service.h"
-#include <sstream>  
+
+// Real implementation only for ESP32-S3; other targets use the inline
+// stub declared in UsbS3Service.h
+#if CONFIG_IDF_TARGET_ESP32S3
+
+#include <sstream>
 #include <esp_mac.h>
 #include <esp32-hal-tinyusb.h>
 #include "freertos/FreeRTOS.h"
@@ -745,3 +750,5 @@ std::string UsbS3Service::getUsbSerialFromEfuseMac() {
 
     return std::string("ESP32-BP-") + macSuffix;
 }
+
+#endif // CONFIG_IDF_TARGET_ESP32S3

--- a/src/Services/UsbS3Service.h
+++ b/src/Services/UsbS3Service.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include <Arduino.h>
+#include <string>
+#include "Interfaces/IUsbS3Service.h"
+
+#if CONFIG_IDF_TARGET_ESP32S3
+
 #include <USB.h>
 #include <USBMSC.h>
 #include <SPI.h>
 #include <SD.h>
-#include <string>
 #include <USBHIDMouse.h>
 #include <USBHIDKeyboard.h>
 #include <USBHIDGamepad.h>
@@ -14,7 +18,6 @@
 #include "usb/usb_types_ch9.h"
 #include "usb/usb_types_stack.h"
 #include "usb/usb_helpers.h"
-#include "Interfaces/IUsbS3Service.h"
 #include "esp_log.h"
 #include <sstream>
 
@@ -48,7 +51,7 @@ public:
     void gamepadBegin();
     void gamepadPress(const std::string& name);
 
-    // Host 
+    // Host
     bool usbHostBegin();
     std::string usbHostTick();
     void usbHostEnd();
@@ -83,7 +86,7 @@ private:
     static int32_t storageWriteCallback(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize);
     static bool usbStartStopCallback(uint8_t power_condition, bool start, bool load_eject);
     void setupStorageEvent();
-    
+
     // Host
     bool stopTinyUsbDevice();
     bool hostInstalled = false;
@@ -94,3 +97,65 @@ private:
     bool dumpedThisAttach = false;
     inline static const char* TAG_USBHOST = "UsbHost";
 };
+
+#else
+
+// Non-functional stub for targets without USB OTG host/device hardware
+// (e.g. ESP32-C6). Mirrors ZigbeeService's unsupported-target behavior:
+// compiles everywhere, all operations are no-ops.
+class UsbS3Service : public IUsbS3Service {
+public:
+    UsbS3Service() = default;
+
+    // Status
+    bool isKeyboardActive() const override { return false; }
+    bool isStorageActive() const override { return false; }
+    bool isMouseActive() const override { return false; }
+    bool isGamepadActive() const override { return false; }
+    bool isHostActive() const override { return false; }
+    bool isSystemControlActive() const override { return false; }
+
+    // Keyboard actions
+    void keyboardBegin() override {}
+    void keyboardSendString(const std::string& text) override { (void)text; }
+    void keyboardSendChunkedString(const std::string& data, size_t chunkSize, unsigned long delayBetweenChunks) override {
+        (void)data; (void)chunkSize; (void)delayBetweenChunks;
+    }
+
+    // Mass Storage mode
+    void storageBegin(uint8_t cs, uint8_t clk, uint8_t miso, uint8_t mosi) override {
+        (void)cs; (void)clk; (void)miso; (void)mosi;
+    }
+
+    // Mouse actions
+    void mouseBegin() override {}
+    void mouseMove(int x, int y) override { (void)x; (void)y; }
+    void mouseClick(int button) override { (void)button; }
+    void mouseRelease(int button) override { (void)button; }
+
+    // Gamepad actions
+    void gamepadBegin() override {}
+    void gamepadPress(const std::string& name) override { (void)name; }
+
+    // Host
+    bool usbHostBegin() override { return false; }
+    std::string usbHostTick() override { return std::string(); }
+    void usbHostEnd() override {}
+
+    // System control
+    void systemControlBegin() override {}
+    void systemControlEnd() override {}
+    void systemSleep() override {}
+    void systemWake() override {}
+    void systemPowerOff(uint32_t holdMs = 10) override { (void)holdMs; }
+
+    // Config
+    void configure(const char* productStr, const char* manufacturerStr, const char* serialStr,
+                   uint16_t vid, uint16_t pid, const char* webUSBString) override {
+        (void)productStr; (void)manufacturerStr; (void)serialStr; (void)vid; (void)pid; (void)webUSBString;
+    }
+    void reset() override {}
+    std::string getUsbSerialFromEfuseMac() override { return std::string(); }
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#ifndef UNIT_TEST
+﻿#ifndef UNIT_TEST
 
 #include <Views/SerialTerminalView.h>
 #include <Views/WebTerminalView.h>
@@ -12,6 +12,7 @@
 #include <Boards/StickS3/StickS3Board.h>
 #include <Boards/StampS3/StampS3Board.h>
 #include <Boards/S3DevKit/S3DevKitBoard.h>
+#include <Boards/C6DevKit/C6DevKitBoard.h>
 #include <Boards/Common/Inputs/DefaultInput.h>
 #include <Boards/TDisplayS3/TDisplayS3Board.h>
 #include <Boards/WaveshareS3Geek/WaveshareS3GeekBoard.h>
@@ -43,7 +44,7 @@ the main loop through the ActionDispatcher.
     * WebTerminalView       -> text terminal in a browser (via WebSocket).
     * CardputerTerminalView -> Cardputer LCD acts as the terminal screen.
 
-- Device View: the interface for device’s screen (if any).
+- Device View: the interface for deviceâ€™s screen (if any).
     * M5DeviceView, St7789SpiDeviceView, St7789ParallelDeviceView, CardputerDeviceView, NoScreenDeviceView, etc.
     * Used for UI elements like mode, pinout mapping, or logic traces.
 
@@ -135,6 +136,12 @@ void setup() {
         IHostSerial& hostSerial = board.getHostSerial();
     #elif defined(DEVICE_S3DEVKIT)
         S3DevKitBoard board;
+        board.initialize();
+        IDeviceView& deviceView = board.getDeviceView();
+        IInput& deviceInput = board.getDeviceInput();
+        IHostSerial& hostSerial = board.getHostSerial();
+    #elif defined(DEVICE_C6DEVKIT)
+        C6DevKitBoard board;
         board.initialize();
         IDeviceView& deviceView = board.getDeviceView();
         IInput& deviceInput = board.getDeviceInput();


### PR DESCRIPTION
## Summary

This PR brings full **ESP32-C6 support** and expands the **Zigbee** feature from a minimal on/off light/switch demo into a practical device emulator and controller.

### ESP32-C6 enablement (first commits)
- ZCZR/ED PlatformIO environments with dedicated Zigbee partition table
- C6 board pins, LP_AON boot register, RISC-V GPIO fixes (OneWire, InfraredToy), HWCDC guards
- UsbS3Service stub on targets without USB host, ESP32SPISlave v0.8.0 for single-SPI-host targets

### Zigbee device emulator & controller
**New emulated endpoints (`device <type>`)**
- `light`, `dimlight`, `colorlight` - On/Off, Dimmable and Color Dimmable Light (hue/saturation, XY and color temperature advertised)
- `tempsensor` - temperature + humidity sensor with injectable fake readings (`settemp 23.5`, `sethum 45`)
- `occupancy` - occupancy sensor with injectable state (`setocc 1`)
- `fan`, `outlet`, `rangeextender` - additional emulation targets

**Switch-side control (paired lights)**
- `dim <0-255 | 0-100%>` - brightness with percent suffix inference
- `color rgb <r g b>` / `color hsv <h s v>` - HSV converted locally to RGB (core 3.3.7 switch API is RGB-only)
- Group addressing: `on/off/toggle/dim/color ... [0x1234]` commands every member at once
- Scenes handled natively by the stack (hub store/recall)

**Visibility**
- New `events` command: bounded log of everything received from the network; color temperature events display mireds **and** Kelvin
- ZIGBEE section added to terminal autocomplete

## Verification done

- Native tests: **681/681 passing** (18 new controller tests covering parsing, scaling, HSV conversion, groups, sensors and events drain)
- Builds green on `c6-devkit-ed` (Flash 91.8%), `c6-devkit` (94.5%) and `s3-devkit` (non-Zigbee stub path)
- Terminal parser path reviewed end-to-end

## Still needs to be done / verified on real hardware

Everything compiles and unit-tests clean, but the runtime paths below never executed - they need a session with a real ESP32-C6 and a Zigbee hub:

1. **Stack bring-up per endpoint type**: endpoint object creation/registration for all types has never run; confirm `setLightColorCapabilities()` before `addEndpoint()` is accepted by core 3.3.7
2. **Commissioning against a hub**: pair as `colorlight`/`tempsensor`, confirm the hub accepts the advertised clusters and that ~30 s sensor reporting arrives
3. **Callback trampolines**: compile-only so far; verify events formatting/timing in `events`, including scene recall
4. **Group commands against multiple real devices**
5. **Flash headroom on `c6-devkit` (94.5%)**: boot + Zigbee NVS untested at this size
6. **Sleepy End Device interaction**: in the ED firmware, sensor sleep vs. reporting intervals may delay/batch received events
7. **Endpoint swap flow**: same stop/reset/addEndpoint pattern as before, but each new type is an untested path through it

## Known limitations (blocked by arduino-esp32 3.3.7)

- No switch-side color temperature command (move-to-color-temp not exposed); unlocks when the platform updates
- Thermostat emulation impossible in this version (class is controller-side only)

README updated with command/device tables and a network recon tip.